### PR TITLE
Fix TrueNAS NFS share API breakage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,12 @@
 module github.com/terrycain/truenas-scale-csi
 
-go 1.21
+go 1.21.4
 
 require (
 	github.com/container-storage-interface/spec v1.8.0
 	github.com/kubernetes-csi/csi-lib-iscsi v0.0.0-20220106022228-366f3190694e
 	github.com/spf13/pflag v1.0.5
-	github.com/terrycain/truenas-go-sdk v0.0.0-20220711232922-263cbeb05e44
+	github.com/terrycain/truenas-go-sdk v0.0.0-20231210135854-9320316561de
 	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b
 	golang.org/x/sync v0.1.0
 	google.golang.org/grpc v1.51.0

--- a/go.sum
+++ b/go.sum
@@ -296,6 +296,10 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/terrycain/truenas-go-sdk v0.0.0-20220711232922-263cbeb05e44 h1:a+dpnE1120L2wlpfDc5OMBeyzHI8a29+AJBZlGRV1J4=
 github.com/terrycain/truenas-go-sdk v0.0.0-20220711232922-263cbeb05e44/go.mod h1:4fpr5n3W9YQ7Jka4XMQujjwc1al+DUjzQhbd9uQtG0M=
+github.com/terrycain/truenas-go-sdk v0.0.0-20231210133812-a3b75565ce90 h1:CHY5nQ61lKJ3ot3LVlhbxrjXTra/hGxLEIoAt0evKE0=
+github.com/terrycain/truenas-go-sdk v0.0.0-20231210133812-a3b75565ce90/go.mod h1:/tZpKAf+L1qGyd3ZMXKWFdNAU9RU67HG5Tx91F2ft1A=
+github.com/terrycain/truenas-go-sdk v0.0.0-20231210135854-9320316561de h1:q+EHI0G4rPbKUHsdsxNqOk7dTcIQkh6inpaihjfsrjY=
+github.com/terrycain/truenas-go-sdk v0.0.0-20231210135854-9320316561de/go.mod h1:/tZpKAf+L1qGyd3ZMXKWFdNAU9RU67HG5Tx91F2ft1A=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -16,7 +16,7 @@ import (
 	"sync"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	tnclient "github.com/terrycain/truenas-go-sdk"
+	tnclient "github.com/terrycain/truenas-go-sdk/pkg/truenas"
 	"golang.org/x/oauth2"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"

--- a/pkg/driver/iscsi_utils.go
+++ b/pkg/driver/iscsi_utils.go
@@ -3,7 +3,7 @@ package driver
 import (
 	"context"
 
-	tnclient "github.com/terrycain/truenas-go-sdk"
+	tnclient "github.com/terrycain/truenas-go-sdk/pkg/truenas"
 )
 
 type (
@@ -14,7 +14,7 @@ type (
 )
 
 func FindISCSIExtent(ctx context.Context, client *tnclient.APIClient, fn ISCSIExtentMatcher) (tnclient.ISCSIExtent, bool, error) {
-	extents, _, err := client.IscsiExtentApi.ListISCSIExtent(ctx).Execute()
+	extents, _, err := client.IscsiExtentAPI.ListISCSIExtent(ctx).Execute()
 	if err != nil {
 		return tnclient.ISCSIExtent{}, false, err
 	}
@@ -29,7 +29,7 @@ func FindISCSIExtent(ctx context.Context, client *tnclient.APIClient, fn ISCSIEx
 }
 
 func FindAllISCSIExtents(ctx context.Context, client *tnclient.APIClient, fn ISCSIExtentMatcher) ([]tnclient.ISCSIExtent, error) {
-	extents, _, err := client.IscsiExtentApi.ListISCSIExtent(ctx).Execute()
+	extents, _, err := client.IscsiExtentAPI.ListISCSIExtent(ctx).Execute()
 	if err != nil {
 		return []tnclient.ISCSIExtent{}, err
 	}
@@ -46,7 +46,7 @@ func FindAllISCSIExtents(ctx context.Context, client *tnclient.APIClient, fn ISC
 }
 
 func FindISCSIInitiator(ctx context.Context, client *tnclient.APIClient, fn ISCSIInitiatorMatcher) (tnclient.ISCSIInitiator, bool, error) {
-	initiators, _, err := client.IscsiInitiatorApi.ListISCSIInitiator(ctx).Execute()
+	initiators, _, err := client.IscsiInitiatorAPI.ListISCSIInitiator(ctx).Execute()
 	if err != nil {
 		return tnclient.ISCSIInitiator{}, false, err
 	}
@@ -61,7 +61,7 @@ func FindISCSIInitiator(ctx context.Context, client *tnclient.APIClient, fn ISCS
 }
 
 func FindISCSITarget(ctx context.Context, client *tnclient.APIClient, fn ISCSITargetMatcher) (tnclient.ISCSITarget, bool, error) {
-	targets, _, err := client.IscsiTargetApi.ListISCSITarget(ctx).Execute()
+	targets, _, err := client.IscsiTargetAPI.ListISCSITarget(ctx).Execute()
 	if err != nil {
 		return tnclient.ISCSITarget{}, false, err
 	}
@@ -76,7 +76,7 @@ func FindISCSITarget(ctx context.Context, client *tnclient.APIClient, fn ISCSITa
 }
 
 func FindAllISCSITargets(ctx context.Context, client *tnclient.APIClient, fn ISCSITargetMatcher) ([]tnclient.ISCSITarget, error) {
-	targets, _, err := client.IscsiTargetApi.ListISCSITarget(ctx).Execute()
+	targets, _, err := client.IscsiTargetAPI.ListISCSITarget(ctx).Execute()
 	if err != nil {
 		return []tnclient.ISCSITarget{}, err
 	}
@@ -93,7 +93,7 @@ func FindAllISCSITargets(ctx context.Context, client *tnclient.APIClient, fn ISC
 }
 
 func FindISCSITargetExtent(ctx context.Context, client *tnclient.APIClient, fn ISCSITargetExtentMatcher) (tnclient.ISCSITargetExtent, bool, error) {
-	targetExtents, _, err := client.IscsiTargetextentApi.ListISCSITargetExtent(ctx).Execute()
+	targetExtents, _, err := client.IscsiTargetextentAPI.ListISCSITargetExtent(ctx).Execute()
 	if err != nil {
 		return tnclient.ISCSITargetExtent{}, false, err
 	}
@@ -108,7 +108,7 @@ func FindISCSITargetExtent(ctx context.Context, client *tnclient.APIClient, fn I
 }
 
 func FindAllISCSITargetExtents(ctx context.Context, client *tnclient.APIClient, fn ISCSITargetExtentMatcher) ([]tnclient.ISCSITargetExtent, error) {
-	targetextents, _, err := client.IscsiTargetextentApi.ListISCSITargetExtent(ctx).Execute()
+	targetextents, _, err := client.IscsiTargetextentAPI.ListISCSITargetExtent(ctx).Execute()
 	if err != nil {
 		return []tnclient.ISCSITargetExtent{}, err
 	}

--- a/pkg/driver/nfs_utils.go
+++ b/pkg/driver/nfs_utils.go
@@ -3,7 +3,7 @@ package driver
 import (
 	"context"
 
-	tnclient "github.com/terrycain/truenas-go-sdk"
+	tnclient "github.com/terrycain/truenas-go-sdk/pkg/truenas"
 )
 
 type (
@@ -12,7 +12,7 @@ type (
 )
 
 func FindDataset(ctx context.Context, client *tnclient.APIClient, fn DatasetMatcher) (tnclient.Dataset, bool, error) {
-	datasets, _, err := client.DatasetApi.ListDatasets(ctx).Execute()
+	datasets, _, err := client.DatasetAPI.ListDatasets(ctx).Execute()
 	if err != nil {
 		return tnclient.Dataset{}, false, err
 	}
@@ -27,7 +27,7 @@ func FindDataset(ctx context.Context, client *tnclient.APIClient, fn DatasetMatc
 }
 
 func FindAllDatasets(ctx context.Context, client *tnclient.APIClient, fn DatasetMatcher) ([]tnclient.Dataset, error) {
-	datasets, _, err := client.DatasetApi.ListDatasets(ctx).Execute()
+	datasets, _, err := client.DatasetAPI.ListDatasets(ctx).Execute()
 	if err != nil {
 		return []tnclient.Dataset{}, err
 	}
@@ -45,7 +45,7 @@ func FindAllDatasets(ctx context.Context, client *tnclient.APIClient, fn Dataset
 }
 
 func FindNFSShare(ctx context.Context, client *tnclient.APIClient, fn NFSShareMatcher) (tnclient.ShareNFS, bool, error) {
-	shares, _, err := client.SharingApi.ListSharesNFS(ctx).Execute()
+	shares, _, err := client.SharingAPI.ListSharesNFS(ctx).Execute()
 	if err != nil {
 		return tnclient.ShareNFS{}, false, err
 	}
@@ -60,7 +60,7 @@ func FindNFSShare(ctx context.Context, client *tnclient.APIClient, fn NFSShareMa
 }
 
 func FindAllNFSShares(ctx context.Context, client *tnclient.APIClient, fn NFSShareMatcher) ([]tnclient.ShareNFS, error) {
-	shares, _, err := client.SharingApi.ListSharesNFS(ctx).Execute()
+	shares, _, err := client.SharingAPI.ListSharesNFS(ctx).Execute()
 	if err != nil {
 		return []tnclient.ShareNFS{}, err
 	}
@@ -75,4 +75,20 @@ func FindAllNFSShares(ctx context.Context, client *tnclient.APIClient, fn NFSSha
 	}
 
 	return result, nil
+}
+
+// NormaliseNFSShareMountpaths Returns a string of the first or only NFS path, empty if none
+// this hides an issues where TrueNAS Scale broke an API without bumping an API version
+// by moving from paths to path.
+func NormaliseNFSShareMountpaths(share tnclient.ShareNFS) string {
+	path := share.GetPath()
+	if len(path) > 0 {
+		return path
+	}
+
+	paths := share.GetPaths()
+	if len(paths) > 0 {
+		return paths[0]
+	}
+	return ""
 }


### PR DESCRIPTION
Fixes #3

TL;DR TrueNAS Scale decided it was a good idea to change the NFS API endpoints from accepting/returning a list of mountpoints `paths` to accepting/returning a singular path. Whilst this is nicer from a consumer point of view, you at least bump the API path from `/api/v2.0` to `/api/v3.0` as the change is not backwards compatible 😒 

Updated the forked [TrueNAS SDK](https://github.com/terrycain/truenas-go-sdk) for a bit of clean up and to add in the `path` request/response variable.

Have yet to test it, but I'm hoping that we can post both `paths` and `path` to the create NFS share endpoint and it just accepts it without complaining about unknown fields. Which for this at least would let us interoperate with the versions either side of this change. 